### PR TITLE
Better replication support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 sudo: false
-script: "bundle exec rake && bundle exec ruby spec/performance_test.rb"
 branches:
   only:
     - master

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,11 @@ require 'bundler/gem_tasks'
 begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
-  task :default => :spec
 rescue LoadError
 end
+
+task :performance_test do
+  ruby 'spec/performance_test.rb'
+end
+
+task :default => [:spec, :performance_test]

--- a/lib/mixed_gauge.rb
+++ b/lib/mixed_gauge.rb
@@ -7,6 +7,7 @@ require 'mixed_gauge/cluster_config'
 require 'mixed_gauge/config'
 require 'mixed_gauge/routing'
 require 'mixed_gauge/shard_repository'
+require 'mixed_gauge/replication_mapping'
 require 'mixed_gauge/all_shards_in_parallel'
 require 'mixed_gauge/model'
 

--- a/lib/mixed_gauge/cluster_config.rb
+++ b/lib/mixed_gauge/cluster_config.rb
@@ -1,7 +1,7 @@
 module MixedGauge
   # Mapping of slot -> connection_name.
   class ClusterConfig
-    attr_reader :name
+    attr_reader :name, :connection_registry
 
     # @param [Symbol] name
     def initialize(name)

--- a/lib/mixed_gauge/replication_mapping.rb
+++ b/lib/mixed_gauge/replication_mapping.rb
@@ -1,0 +1,35 @@
+module MixedGauge
+  class ReplicationMapping
+    def initialize(mapping)
+      @mapping = mapping
+      @lock = Mutex.new
+    end
+
+    # @param [Class] A shard model having connection to specific shard
+    # @param [Symbol] A role name of target cluster.
+    # @return [Class, Object] if block given then yielded result else
+    #   target shard model.
+    def switch(from, role_name, &block)
+      @lock.synchronize { constantize! unless constantized? }
+
+      model = @mapping.fetch(role_name)
+      target_shard_model = model.shard_repository.fetch_by_slots(from.assigned_slots)
+
+      if block_given?
+        target_shard_model.connection_pool.with_connection { yield target_shard_model }
+      else
+        target_shard_model
+      end
+    end
+
+    private
+
+    def constantize!
+      @mapping = Hash[@mapping.map {|k, name| [k, name.to_s.constantize] }]
+    end
+
+    def constantized?
+      @mapping.values.first.is_a? Class
+    end
+  end
+end

--- a/lib/mixed_gauge/shard_repository.rb
+++ b/lib/mixed_gauge/shard_repository.rb
@@ -7,8 +7,8 @@ module MixedGauge
     def initialize(cluster_config, base_class)
       @base_class = base_class
 
-      shards = cluster_config.connections.map do |connection_name|
-        [connection_name, generate_model_for_shard(connection_name)]
+      shards = cluster_config.connection_registry.map do |slot_range, connection_name|
+        [connection_name, generate_model_for_shard(connection_name, slot_range)]
       end
       @shards = Hash[shards]
     end
@@ -19,6 +19,12 @@ module MixedGauge
       @shards.fetch(connection_name)
     end
 
+    # @param [Range] slots
+    # @return [Class, nil] A AR model class.
+    def fetch_by_slots(assigned_slots)
+      @shards.find {|_, model| model.assigned_slots == assigned_slots }[1]
+    end
+
     # @return [Array<Class>]
     def all
       @shards.values
@@ -27,13 +33,19 @@ module MixedGauge
     private
 
     # @param [Symbol] connection_name
+    # @param [Range] slot_range
     # @return [Class] A sub class of given AR model.
     #   A sub class has connection setting for specific shard.
-    def generate_model_for_shard(connection_name)
+    def generate_model_for_shard(connection_name, slot_range)
       base_class_name = @base_class.name
       class_name = generate_class_name(connection_name)
 
       model = Class.new(base_class) do
+        class << self
+          attr_reader :assigned_slots
+        end
+        @assigned_slots = slot_range
+
         self.table_name = base_class.table_name
         module_eval <<-RUBY, __FILE__, __LINE__ + 1
           def self.name

--- a/spec/mixed_gauge/database_tasks_spec.rb
+++ b/spec/mixed_gauge/database_tasks_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe MixedGauge::DatabaseTasks do
 
   describe '#cluster_names' do
     it 'retuns an Array of cluster name' do
-      expect(described_class.cluster_names).to eq([:user])
+      expect(described_class.cluster_names).to eq([:user, :user_readonly])
     end
   end
 
   describe '#clusters' do
     it 'retuns an Array of cluster config' do
       result = described_class.clusters
-      expect(result.size).to eq(1)
+      expect(result.size).to eq(2)
       expect(result).to all(a_kind_of(MixedGauge::ClusterConfig))
     end
   end

--- a/spec/mixed_gauge/model_spec.rb
+++ b/spec/mixed_gauge/model_spec.rb
@@ -123,6 +123,13 @@ RSpec.describe MixedGauge::Model do
     end
   end
 
+  describe '.switch' do
+    it 'retuns result' do
+      result = User.shard_for('x').switch(:slave) { 1 }
+      expect(result).to eq(1)
+    end
+  end
+
   describe '.parent_methods' do
     before do
       model.put!(user_attributes)

--- a/spec/mixed_gauge/replication_mapping_spec.rb
+++ b/spec/mixed_gauge/replication_mapping_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+# See spec/models.rb about model definitions
+RSpec.describe MixedGauge::ReplicationMapping do
+  let(:mapping) { described_class.new(slave: :UserReadonly) }
+
+  describe '#switch' do
+    let(:key) { 'xxx' }
+    let(:shard_for_master) { User.shard_for(key) }
+    let(:shard_for_slave) { UserReadonly.shard_for(key) }
+
+    context 'without block' do
+      it 'retuns target shard model' do
+        expect(mapping.switch(shard_for_master, :slave)).to eq(shard_for_slave)
+      end
+    end
+
+    context 'with block' do
+      it 'yields target shard model and retuns block result' do
+        result = mapping.switch(shard_for_master, :slave) do |m|
+          expect(m).to eq(shard_for_slave)
+          1
+        end
+        expect(result).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -4,6 +4,10 @@ ActiveRecord::Base.configurations = {
   'test_user_002' => base.merge('database' => 'user_002.sqlite3'),
   'test_user_003' => base.merge('database' => 'user_003.sqlite3'),
   'test_user_004' => base.merge('database' => 'user_004.sqlite3'),
+  'test_user_readonly_001' => base.merge('database' => 'user_001.sqlite3'),
+  'test_user_readonly_002' => base.merge('database' => 'user_002.sqlite3'),
+  'test_user_readonly_003' => base.merge('database' => 'user_003.sqlite3'),
+  'test_user_readonly_004' => base.merge('database' => 'user_004.sqlite3'),
   'test' => base.merge('database' => 'default.sqlite3')
 }
 ActiveRecord::Base.establish_connection(:test)
@@ -16,10 +20,27 @@ MixedGauge.configure do |config|
     cluster.register(524288..786431, :test_user_003)
     cluster.register(786432..1048575, :test_user_004)
   end
+
+  config.define_cluster(:user_readonly) do |cluster|
+    cluster.define_slot_size(1048576)
+    cluster.register(0..262143, :test_user_readonly_001)
+    cluster.register(262144..524287, :test_user_readonly_002)
+    cluster.register(524288..786431, :test_user_readonly_003)
+    cluster.register(786432..1048575, :test_user_readonly_004)
+  end
 end
 
 class User < ActiveRecord::Base
   include MixedGauge::Model
   use_cluster :user
   def_distkey :email
+  replicates_with slave: :UserReadonly
+end
+
+class UserReadonly < ActiveRecord::Base
+  self.table_name = 'users'
+  include MixedGauge::Model
+  use_cluster :user_readonly
+  def_distkey :email
+  replicates_with master: :User
 end

--- a/spec/performance_test.rb
+++ b/spec/performance_test.rb
@@ -19,7 +19,7 @@ puts '=== Performance test result ==='
 puts "#{n} times of `User.shard_for` tooks #{elasped_time} sec"
 puts '===        End result       ==='
 
-if elasped_time >= 0.01
+if elasped_time >= 0.1
   exit 1
 else
   exit


### PR DESCRIPTION
Sometimes, we use replication to reduce load of master instance. In these cases, we reads from specific instance then writes to another instance, but these both instance must have exactly same responsibility for assined hash slots. We can do that dirtily (i.e. maching class name of model) but mixed_guage can support these cases by having that mapping internally and offering interface to get mapped model class.
